### PR TITLE
Implement missing sort of cluster centers by id in KMeans model loader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [Unreleased]
+### Fixed
+- [#23](https://github.com/BixData/stuart-ml/issues/23) KMeans cluster centers load in a non-deterministic sort order due to missing sort
+
 ## [0.1.8] - 2018-10-14
 ### Added
 - Lua 5.3 support

--- a/spec/clustering/KMeansModel_spec.lua
+++ b/spec/clustering/KMeansModel_spec.lua
@@ -2,7 +2,7 @@ local hasSparkSession, _ = pcall(require, 'stuart-sql.SparkSession')
 local KMeansModel = require 'stuart-ml.clustering.KMeansModel'
 local registerAsserts = require 'registerAsserts'
 local stuart = require 'stuart'
---local Vectors = require 'stuart-ml.linalg.Vectors'
+local Vectors = require 'stuart-ml.linalg.Vectors'
 
 registerAsserts(assert)
 
@@ -21,9 +21,9 @@ describe('clustering.KMeansModel', function()
     local sc = stuart.NewContext()
     local model = KMeansModel.load(sc, 'spec-fixtures/model4')
     assert.equal(2, #model.clusterCenters)
---    assert.same({1,2,3}, model.clusterCenters:toArray())
---    assert.same({5,6,7}, model.clusterCenters:toArray())
---    assert.equal(1, model:predict(Vectors.dense({5,6,7})))
+    assert.same({5,6,7}, model.clusterCenters[1]:toArray())
+    assert.same({1,2,3}, model.clusterCenters[2]:toArray())
+    assert.equal(1, model:predict(Vectors.dense({5,6,7})))
   end)
 
 end)

--- a/src/stuart-ml/clustering/KMeansModel.lua
+++ b/src/stuart-ml/clustering/KMeansModel.lua
@@ -24,11 +24,10 @@ function KMeansModel.load(sc, path)
   assert(className == 'org.apache.spark.mllib.clustering.KMeansModel')
   assert(formatVersion == '1.0')
   local centroids = spark.read:parquet(Loader.dataPath(path))
-  --Loader.checkSchema[Cluster](centroids.schema)
+  --TODO Loader.checkSchema[Cluster](centroids.schema)
   local localCentroids = centroids:rdd():map(function(e) return {e[1], Vectors.dense(e[2])} end)
   assert(metadata.k == localCentroids:count())
-  --new KMeansModel(localCentroids.sortBy(_.id).map(_.point))
-  return KMeansModel:new(localCentroids:map(function(e) return e[2] end):collect())
+  return KMeansModel:new(localCentroids:sortByKey():map(function(e) return e[2] end):collect())
 end
 
 function KMeansModel:predict(point)


### PR DESCRIPTION
Fixes #23 