### PR TITLE
Fix VectorWithNorm initializer computing a vector's norm when not provided

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [Unreleased]
 ### Fixed
 - [#23](https://github.com/BixData/stuart-ml/issues/23) KMeans cluster centers load in a non-deterministic sort order due to missing sort
+- [#25](https://github.com/BixData/stuart-ml/issues/25) VectorWithNorm initializer fails to compute norm when not explicitly provided
 
 ## [0.1.8] - 2018-10-14
 ### Added

--- a/spec/clustering/KMeans_spec.lua
+++ b/spec/clustering/KMeans_spec.lua
@@ -1,5 +1,7 @@
 local registerAsserts = require 'registerAsserts'
 local KMeans = require 'stuart-ml.clustering.KMeans'
+local Vectors = require 'stuart-ml.linalg.Vectors'
+local VectorWithNorm = require 'stuart-ml.clustering.VectorWithNorm'
 
 registerAsserts(assert)
 
@@ -37,6 +39,26 @@ describe('clustering.KMeans', function()
     assert.has_error(function()
       KMeans:new():setInitializationSteps(0)
     end)
+  end)
+
+  it('findClosest() with exact match works', function()
+    local centers = {
+      VectorWithNorm:new(Vectors.dense(1,2,6))
+    }
+    local point = VectorWithNorm:new(Vectors.dense(1,2,6))
+    local bestIndex, bestDistance = KMeans.findClosest(centers, point)
+    assert.equal(1, bestIndex)
+    assert.equal(0, bestDistance)
+  end)
+
+  it('findClosest() with near match works', function()
+    local centers = {
+      VectorWithNorm:new(Vectors.dense(1,2,6))
+    }
+    local point = VectorWithNorm:new(Vectors.dense(1,3,0))
+    local bestIndex, bestDistance = KMeans.findClosest(centers, point)
+    assert.equal(1, bestIndex)
+    assert.equal(37, bestDistance)
   end)
   
 end)

--- a/src/stuart-ml/clustering/VectorWithNorm.lua
+++ b/src/stuart-ml/clustering/VectorWithNorm.lua
@@ -12,10 +12,10 @@ local VectorWithNorm = class('VectorWithNorm')
 function VectorWithNorm:initialize(arg1, norm)
   if isInstanceOf(arg1, Vector) then
     self.vector = arg1
-  else -- arg1 is an array
+  else -- arg1 is a table
     self.vector = Vectors.dense(arg1)
   end
-  self.norm = norm or 2.0
+  self.norm = norm or Vectors.norm(self.vector, 2.0)
 end
 
 function VectorWithNorm.__eq(a, b)


### PR DESCRIPTION
Fixes #25