### PR TITLE
Remove unnecessary use of table.pack(), which is not available in all versions of Lua

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [Unreleased]
+### Fixed
+- [#38](https://github.com/BixData/stuart-ml/issues/38) Vectors.dense(...) with varargs error: no table.pack() function (eLua interop)
+
 ## [1.0.0] - 2018-11-08
 ### Changed
 - Upgrade to Stuart 1.0.0 with changes to class framework

--- a/spec/linalg/ApacheSpark_VectorsSuite_spec.lua
+++ b/spec/linalg/ApacheSpark_VectorsSuite_spec.lua
@@ -13,16 +13,11 @@ describe('Apache Spark MLlib VectorsSuite', function()
   local values = {0.1, 0.3, 0.4}
 
   it('dense vector construction with varargs', function()
-    local vec = Vectors.dense(arr)
+    local unpack = table.unpack or unpack
+    local vec = Vectors.dense(unpack(arr))
     assert.equal(#arr, vec:size())
     assert.same(arr, vec.values)
   end)
-
---  it('dense vector construction from a double array', function()
---   val vec = Vectors.dense(arr).asInstanceOf[DenseVector]
---    assert(vec.size === arr.length)
---    assert(vec.values.eq(arr))
---  end)
 
   it('sparse vector construction', function()
     local vec = Vectors.sparse(n, indices, values)

--- a/src/stuart-ml/linalg/Vectors.lua
+++ b/src/stuart-ml/linalg/Vectors.lua
@@ -6,9 +6,7 @@ M.dense = function(...)
   if moses.isTable(...) then
     return DenseVector.new(...)
   else
-    local values = table.pack(...)
-    values.n = nil
-    return DenseVector.new(values)
+    return DenseVector.new({...})
   end
 end
 


### PR DESCRIPTION
Fixes #38 