### PR TITLE
The binarySearch() Java compat utility now uses 1-based indexes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 - `linalg:` Ported `BLAS` `spr()`
 - `linalg:` Ported `Matrix` `copy()` and `toString()`, and implemented `clone()` to make matrices usable within RDD functions as a zero value parameter
 
+### Fixed
+- [#56](https://github.com/BixData/stuart-ml/issues/56) Java array `binarySearch()` claimed to use 1-based index params and an exclusive end-index, but used 0-based index params and an inclusive end-index
+
 ## [2.0.2] - 2019-02-23
 ### Added
 - Document how to train a K-means model within Redis at [examples/redis-kmeans](./examples/redis-kmeans/)

--- a/spec/util/java/arrays_spec.lua
+++ b/spec/util/java/arrays_spec.lua
@@ -3,20 +3,20 @@ local arrays = require 'stuart-ml.util.java.arrays'
 describe('Java Utils :: Arrays', function()
 
   it('binarySearch() with odd number of elements', function()
-    local t = {1,2,3}
-    assert.equal(0 , arrays.binarySearch(t, 0, #t, 1))
-    assert.equal(1 , arrays.binarySearch(t, 0, #t, 2))
-    assert.equal(2 , arrays.binarySearch(t, 0, #t, 3))
-    assert.equal(-3, arrays.binarySearch(t, 0, #t, 4))
+    local t = {11,12,13}
+    assert.equal(1 , arrays.binarySearch(t, 1, #t+1, 11))
+    assert.equal(2 , arrays.binarySearch(t, 1, #t+1, 12))
+    assert.equal(3 , arrays.binarySearch(t, 1, #t+1, 13))
+    assert.equal(-4, arrays.binarySearch(t, 1, #t+1, 14))
   end)
   
   it('binarySearch() with even number of elements', function()
-    local t = {1,2,3,4}
-    assert.equal(0 , arrays.binarySearch(t, 0, #t, 1))
-    assert.equal(1 , arrays.binarySearch(t, 0, #t, 2))
-    assert.equal(2 , arrays.binarySearch(t, 0, #t, 3))
-    assert.equal(3 , arrays.binarySearch(t, 0, #t, 4))
-    assert.equal(-4, arrays.binarySearch(t, 0, #t, 5))
+    local t = {11,12,13,14}
+    assert.equal(1 , arrays.binarySearch(t, 1, #t+1, 11))
+    assert.equal(2 , arrays.binarySearch(t, 1, #t+1, 12))
+    assert.equal(3 , arrays.binarySearch(t, 1, #t+1, 13))
+    assert.equal(4 , arrays.binarySearch(t, 1, #t+1, 14))
+    assert.equal(-5, arrays.binarySearch(t, 1, #t+1, 15))
   end)
   
   -- https://alvinalexander.com/source-code/scala/scala-tabulate-method-use-list-array-vector-seq-and-more

--- a/src/stuart-ml/linalg/SparseMatrix.lua
+++ b/src/stuart-ml/linalg/SparseMatrix.lua
@@ -131,9 +131,9 @@ function SparseMatrix:index(i, j)
   assert(j >= 0 and j < self.numCols)
   local arrays = require 'stuart-ml.util.java.arrays'
   if not self.isTransposed then
-    return arrays.binarySearch(self.rowIndices, self.colPtrs[j+1], self.colPtrs[j+2], i+1)
+    return arrays.binarySearch(self.rowIndices, self.colPtrs[j+1]+1, self.colPtrs[j+2]+1, i)
   else
-    return arrays.binarySearch(self.rowIndices, self.colPtrs[i+1], self.colPtrs[i+2], j+1)
+    return arrays.binarySearch(self.rowIndices, self.colPtrs[i+1]+1, self.colPtrs[i+2]+1, j)
   end
 end
 

--- a/src/stuart-ml/util/java/arrays.lua
+++ b/src/stuart-ml/util/java/arrays.lua
@@ -4,13 +4,12 @@ local M = {}
 --            (but conforming to Lua 1-based table indexes instead of Java's 0-based indexes)
 -- implementation: https://stackoverflow.com/questions/19522451/binary-search-of-an-array-of-arrays-in-lua
 M.binarySearch = function(a, fromIndex, toIndex, key)
-  fromIndex = fromIndex or 0
-  assert(fromIndex >= 0, 'fromIndex must be >= 0')
-  toIndex = toIndex or nil
-  if toIndex == nil then toIndex = #a end
+  fromIndex = fromIndex or 1
+  assert(fromIndex >= 1)
+  toIndex = toIndex or #a+1
   while fromIndex < toIndex do
     local mid = math.floor((fromIndex+toIndex) / 2)
-    local midVal = a[mid+1]
+    local midVal = a[mid]
     if midVal < key then
       fromIndex = mid+1
     elseif midVal > key then


### PR DESCRIPTION
Fixes #56 